### PR TITLE
ci:Change web service port mapping to 3015

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     container_name: web_apache_php
     ports:
-      - "8888:80"
+      - "3015:80"
     volumes:
       - ./src:/var/www/html
       - ./docker-setup.sh:/docker-setup.sh


### PR DESCRIPTION
Updated the docker-compose.yml to map host port 3015 to container port 80 for the web_apache_php service instead of the previous 8888. This may be to avoid port conflicts or to standardize port usage.